### PR TITLE
Fix 'OHTAPI::getQuotations' method

### DIFF
--- a/lib/OHTAPI.php
+++ b/lib/OHTAPI.php
@@ -726,11 +726,14 @@ class OHTAPI
             throw new \Exception('Please specify at least sources or wordcount.');
         }
 
+        if (!empty($resources)) {
+            $params['resources'] = $resources;
+        }
+
         $url = "/tools/quote";
         $method = 'get';
         $params['source_language'] = $sourceLangauge;
         $params['target_language'] = $targetLanguage;
-        $params['resources'] = $resources;
         $params['wordcount'] = $wordcount;
         $params['currency'] = $currency;
         $params['proofreading'] = $proofreading;


### PR DESCRIPTION
Fix 'getQuotations' in case when `resources` param not passed (value is empty string), only `wordcount` passed.

Official documentation said:
"resources - Comma (,) separated list of resource_uuid. This field is **mandatory** if "wordcount" not specified.". But this field is not necessary if `wordcount` specified. 